### PR TITLE
fix: Console spam from MySQL health check

### DIFF
--- a/src/DotnetActuatorMiddleware/Health/Checks/MySqlHealthCheck.cs
+++ b/src/DotnetActuatorMiddleware/Health/Checks/MySqlHealthCheck.cs
@@ -22,7 +22,6 @@ public static class MySqlHealthCheck
                 cmd.CommandText = "SELECT @@version AS version, @@port AS port, @@hostname AS hostname";
                 var reader = cmd.ExecuteReader();
                 reader.Read();
-                Console.WriteLine(reader.GetString("hostname"));
 
                 return HealthResponse.Healthy(new MySqlHealthCheckResponse { Host = reader.GetString("hostname"), Port = reader.GetInt32("port") , Version = reader.GetString("version")});
                 


### PR DESCRIPTION
There was a Console.WriteLine left in the MySQL health check from early development that would print a line every time the health check was called.