### PR TITLE
fix: Switch to StaticConnectionPool

### DIFF
--- a/src/DotnetActuatorMiddleware/Health/Checks/ElasticsearchHealthCheck.cs
+++ b/src/DotnetActuatorMiddleware/Health/Checks/ElasticsearchHealthCheck.cs
@@ -18,7 +18,7 @@ public static class ElasticsearchHealthCheck
     {
         try
         {
-            var connectionPool = new SniffingConnectionPool(servers);
+            var connectionPool = new StaticConnectionPool(servers);
             var settings = new ConnectionConfiguration(connectionPool)
                 .SniffOnStartup(false)
                 .RequestTimeout(TimeSpan.FromSeconds(timeoutSecs));


### PR DESCRIPTION
A sniffing connection pool does not work with certain cloud providers like AWS or Elastic Cloud who use load balancers in front of their clusters.